### PR TITLE
Update to support 1.16.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,12 +2,12 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/use
-minecraft_version=1.16.1
-yarn_mappings=1.16.1+build.21
-loader_version=0.9.0+build.204
+minecraft_version=1.16.2
+yarn_mappings=1.16.2+build.19
+loader_version=0.9.1+build.205
 
 #Fabric api
-fabric_version=0.13.1+build.370-1.16
+fabric_version=0.18.0+build.397-1.16
 
 # Mod Properties
 mod_version=0.2.4

--- a/src/main/java/supercoder79/cavebiomes/BiomeHandler.java
+++ b/src/main/java/supercoder79/cavebiomes/BiomeHandler.java
@@ -6,149 +6,27 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.BiomeKeys;
 import net.minecraft.world.gen.surfacebuilder.SurfaceConfig;
+import supercoder79.cavebiomes.cave.CaveDecorator;
 import supercoder79.cavebiomes.cave.CaveDecorators;
 
-import static supercoder79.cavebiomes.CaveBiomes.BIOME2CD;
+import static supercoder79.cavebiomes.CaveBiomes.BIOME_CATEGORY_2CD;
 
 public class BiomeHandler {
-    private static boolean fullyInitialized = false;
 
     public static void addVanillaBiomes() {
-        //ice biomes
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.ICE_SPIKES), CaveDecorators.ICE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_BEACH), CaveDecorators.ICE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_MOUNTAINS), CaveDecorators.ICE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_TAIGA), CaveDecorators.ICE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_TAIGA_HILLS), CaveDecorators.ICE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_TAIGA_MOUNTAINS), CaveDecorators.ICE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_TUNDRA), CaveDecorators.ICE);
-
-        //taiga biomes
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TAIGA), CaveDecorators.TAIGA);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TAIGA_HILLS), CaveDecorators.TAIGA);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TAIGA_MOUNTAINS), CaveDecorators.TAIGA);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GIANT_SPRUCE_TAIGA), CaveDecorators.TAIGA);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GIANT_SPRUCE_TAIGA_HILLS), CaveDecorators.TAIGA);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GIANT_TREE_TAIGA), CaveDecorators.TAIGA);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GIANT_TREE_TAIGA_HILLS), CaveDecorators.TAIGA);
-
-        //grassy biomes (fallback)
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.PLAINS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.FOREST), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.WOODED_HILLS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BIRCH_FOREST), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BIRCH_FOREST_HILLS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TALL_BIRCH_FOREST), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TALL_BIRCH_HILLS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DARK_FOREST), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DARK_FOREST_HILLS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MOUNTAINS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MOUNTAIN_EDGE), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_GRAVELLY_MOUNTAINS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GRAVELLY_MOUNTAINS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.WOODED_MOUNTAINS), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SAVANNA), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SAVANNA_PLATEAU), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SHATTERED_SAVANNA), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SHATTERED_SAVANNA_PLATEAU), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.FLOWER_FOREST), CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SUNFLOWER_PLAINS), CaveDecorators.DIRT_GRASS);
-
-        //swamp biomes
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SWAMP), CaveDecorators.SWAMP);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SWAMP_HILLS), CaveDecorators.SWAMP);
-
-        //jungle biomes
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.JUNGLE), CaveDecorators.JUNGLE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.JUNGLE_EDGE), CaveDecorators.JUNGLE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.JUNGLE_HILLS), CaveDecorators.JUNGLE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BAMBOO_JUNGLE), CaveDecorators.JUNGLE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_JUNGLE), CaveDecorators.JUNGLE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BAMBOO_JUNGLE_HILLS), CaveDecorators.JUNGLE);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_JUNGLE_EDGE), CaveDecorators.JUNGLE);
-
-        //sand biomes
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DESERT), CaveDecorators.SAND);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DESERT_HILLS), CaveDecorators.SAND);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DESERT_LAKES), CaveDecorators.SAND);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BEACH), CaveDecorators.SAND);
-
-        //red sand biomes
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BADLANDS), CaveDecorators.RED_SAND);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BADLANDS_PLATEAU), CaveDecorators.RED_SAND);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.ERODED_BADLANDS), CaveDecorators.RED_SAND);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_BADLANDS_PLATEAU), CaveDecorators.RED_SAND);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_WOODED_BADLANDS_PLATEAU), CaveDecorators.RED_SAND);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.WOODED_BADLANDS_PLATEAU), CaveDecorators.RED_SAND);
-
-        //mushroom biomes
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MUSHROOM_FIELDS), CaveDecorators.MUSHROOM);
-        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MUSHROOM_FIELD_SHORE), CaveDecorators.MUSHROOM);
-    }
-
-    public static void attemptAddRemainingBiomes() {
-        if (!CaveBiomes.CONFIG.guessCaveBiomeIfAbsent) return;
-
-        if (fullyInitialized) return;
-
-        fullyInitialized = true;
-
-        for (Biome biome : BuiltinRegistries.BIOME) {
-            BIOME2CD.computeIfAbsent(biome, b -> {
-               //attempt to add biome heuristically
-
-                //if it's icy, or has snow, register snowy cave
-                if (b.getCategory() == Biome.Category.ICY || b.getPrecipitation() == Biome.Precipitation.SNOW) {
-                    return CaveDecorators.ICE;
-                }
-
-                //if it's a jungle, register jungle cave
-                if (b.getCategory() == Biome.Category.JUNGLE) {
-                    return CaveDecorators.JUNGLE;
-                }
-
-                //if it's a swamp, register swamp cave
-                if (b.getCategory() == Biome.Category.SWAMP) {
-                    return CaveDecorators.SWAMP;
-                }
-
-                //if it's a taiga, register taiga cave
-                if (b.getCategory() == Biome.Category.TAIGA) {
-                    return CaveDecorators.TAIGA;
-                }
-
-                //if it's a desert or beach, register sand cave
-                if (b.getCategory() == Biome.Category.DESERT || b.getCategory() == Biome.Category.BEACH) {
-                    return CaveDecorators.SAND;
-                }
-
-                //if it's a mesa, register red sand cave
-                if (b.getCategory() == Biome.Category.MESA) {
-                    return CaveDecorators.RED_SAND;
-                }
-
-                //So at this point we've gone through every catagory and tried our best to guess which cave would fit it.
-                //Now if we still don't know at this point, we look at the surface config and try to guess that way.
-
-                SurfaceConfig sc = b.getGenerationSettings().getSurfaceConfig();
-
-                //grassy surface - grassy cave
-                if (sc.getTopMaterial() == Blocks.GRASS_BLOCK.getDefaultState()) {
-                    return CaveDecorators.DIRT_GRASS;
-                }
-
-                //sandy surface - sandy cave
-                if (sc.getTopMaterial() == Blocks.SAND.getDefaultState()) {
-                    return CaveDecorators.SAND;
-                }
-
-                //sandy surface - sandy cave
-                if (sc.getTopMaterial() == Blocks.RED_SAND.getDefaultState()) {
-                    return CaveDecorators.RED_SAND;
-                }
-
-                return CaveDecorators.NONE;
-            });
-        }
+        BIOME_CATEGORY_2CD.put(Biome.Category.ICY, CaveDecorators.ICE);
+        BIOME_CATEGORY_2CD.put(Biome.Category.JUNGLE, CaveDecorators.JUNGLE);
+        BIOME_CATEGORY_2CD.put(Biome.Category.SWAMP, CaveDecorators.SWAMP);
+        BIOME_CATEGORY_2CD.put(Biome.Category.TAIGA, CaveDecorators.TAIGA);
+        BIOME_CATEGORY_2CD.put(Biome.Category.DESERT, CaveDecorators.SAND);
+        BIOME_CATEGORY_2CD.put(Biome.Category.MESA, CaveDecorators.RED_SAND);
+        BIOME_CATEGORY_2CD.put(Biome.Category.BEACH, CaveDecorators.SAND);
+        BIOME_CATEGORY_2CD.put(Biome.Category.EXTREME_HILLS, CaveDecorators.DIRT_GRASS);
+        BIOME_CATEGORY_2CD.put(Biome.Category.FOREST, CaveDecorators.JUNGLE);
+        BIOME_CATEGORY_2CD.put(Biome.Category.MUSHROOM, CaveDecorators.MUSHROOM);
+        BIOME_CATEGORY_2CD.put(Biome.Category.PLAINS, CaveDecorators.DIRT_GRASS);
+        BIOME_CATEGORY_2CD.put(Biome.Category.SAVANNA, CaveDecorators.RED_SAND);
+        BIOME_CATEGORY_2CD.put(Biome.Category.RIVER, CaveDecorators.DIRT_GRASS);
+        BIOME_CATEGORY_2CD.put(Biome.Category.OCEAN, CaveDecorators.NONE);
     }
 }

--- a/src/main/java/supercoder79/cavebiomes/BiomeHandler.java
+++ b/src/main/java/supercoder79/cavebiomes/BiomeHandler.java
@@ -1,9 +1,10 @@
 package supercoder79.cavebiomes;
 
 import net.minecraft.block.Blocks;
+import net.minecraft.util.registry.BuiltinRegistries;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.Biomes;
+import net.minecraft.world.biome.BiomeKeys;
 import net.minecraft.world.gen.surfacebuilder.SurfaceConfig;
 import supercoder79.cavebiomes.cave.CaveDecorators;
 
@@ -14,75 +15,75 @@ public class BiomeHandler {
 
     public static void addVanillaBiomes() {
         //ice biomes
-        BIOME2CD.put(Biomes.ICE_SPIKES, CaveDecorators.ICE);
-        BIOME2CD.put(Biomes.SNOWY_BEACH, CaveDecorators.ICE);
-        BIOME2CD.put(Biomes.SNOWY_MOUNTAINS, CaveDecorators.ICE);
-        BIOME2CD.put(Biomes.SNOWY_TAIGA, CaveDecorators.ICE);
-        BIOME2CD.put(Biomes.SNOWY_TAIGA_HILLS, CaveDecorators.ICE);
-        BIOME2CD.put(Biomes.SNOWY_TAIGA_MOUNTAINS, CaveDecorators.ICE);
-        BIOME2CD.put(Biomes.SNOWY_TUNDRA, CaveDecorators.ICE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.ICE_SPIKES), CaveDecorators.ICE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_BEACH), CaveDecorators.ICE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_MOUNTAINS), CaveDecorators.ICE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_TAIGA), CaveDecorators.ICE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_TAIGA_HILLS), CaveDecorators.ICE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_TAIGA_MOUNTAINS), CaveDecorators.ICE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SNOWY_TUNDRA), CaveDecorators.ICE);
 
         //taiga biomes
-        BIOME2CD.put(Biomes.TAIGA, CaveDecorators.TAIGA);
-        BIOME2CD.put(Biomes.TAIGA_HILLS, CaveDecorators.TAIGA);
-        BIOME2CD.put(Biomes.TAIGA_MOUNTAINS, CaveDecorators.TAIGA);
-        BIOME2CD.put(Biomes.GIANT_SPRUCE_TAIGA, CaveDecorators.TAIGA);
-        BIOME2CD.put(Biomes.GIANT_SPRUCE_TAIGA_HILLS, CaveDecorators.TAIGA);
-        BIOME2CD.put(Biomes.GIANT_TREE_TAIGA, CaveDecorators.TAIGA);
-        BIOME2CD.put(Biomes.GIANT_TREE_TAIGA_HILLS, CaveDecorators.TAIGA);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TAIGA), CaveDecorators.TAIGA);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TAIGA_HILLS), CaveDecorators.TAIGA);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TAIGA_MOUNTAINS), CaveDecorators.TAIGA);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GIANT_SPRUCE_TAIGA), CaveDecorators.TAIGA);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GIANT_SPRUCE_TAIGA_HILLS), CaveDecorators.TAIGA);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GIANT_TREE_TAIGA), CaveDecorators.TAIGA);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GIANT_TREE_TAIGA_HILLS), CaveDecorators.TAIGA);
 
         //grassy biomes (fallback)
-        BIOME2CD.put(Biomes.PLAINS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.FOREST, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.WOODED_HILLS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.BIRCH_FOREST, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.BIRCH_FOREST_HILLS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.TALL_BIRCH_FOREST, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.TALL_BIRCH_HILLS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.DARK_FOREST, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.DARK_FOREST_HILLS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.MOUNTAINS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.MOUNTAIN_EDGE, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.MODIFIED_GRAVELLY_MOUNTAINS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.GRAVELLY_MOUNTAINS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.WOODED_MOUNTAINS, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.SAVANNA, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.SAVANNA_PLATEAU, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.SHATTERED_SAVANNA, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.SHATTERED_SAVANNA_PLATEAU, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.FLOWER_FOREST, CaveDecorators.DIRT_GRASS);
-        BIOME2CD.put(Biomes.SUNFLOWER_PLAINS, CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.PLAINS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.FOREST), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.WOODED_HILLS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BIRCH_FOREST), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BIRCH_FOREST_HILLS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TALL_BIRCH_FOREST), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.TALL_BIRCH_HILLS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DARK_FOREST), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DARK_FOREST_HILLS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MOUNTAINS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MOUNTAIN_EDGE), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_GRAVELLY_MOUNTAINS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.GRAVELLY_MOUNTAINS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.WOODED_MOUNTAINS), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SAVANNA), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SAVANNA_PLATEAU), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SHATTERED_SAVANNA), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SHATTERED_SAVANNA_PLATEAU), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.FLOWER_FOREST), CaveDecorators.DIRT_GRASS);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SUNFLOWER_PLAINS), CaveDecorators.DIRT_GRASS);
 
         //swamp biomes
-        BIOME2CD.put(Biomes.SWAMP, CaveDecorators.SWAMP);
-        BIOME2CD.put(Biomes.SWAMP_HILLS, CaveDecorators.SWAMP);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SWAMP), CaveDecorators.SWAMP);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.SWAMP_HILLS), CaveDecorators.SWAMP);
 
         //jungle biomes
-        BIOME2CD.put(Biomes.JUNGLE, CaveDecorators.JUNGLE);
-        BIOME2CD.put(Biomes.JUNGLE_EDGE, CaveDecorators.JUNGLE);
-        BIOME2CD.put(Biomes.JUNGLE_HILLS, CaveDecorators.JUNGLE);
-        BIOME2CD.put(Biomes.BAMBOO_JUNGLE, CaveDecorators.JUNGLE);
-        BIOME2CD.put(Biomes.MODIFIED_JUNGLE, CaveDecorators.JUNGLE);
-        BIOME2CD.put(Biomes.BAMBOO_JUNGLE_HILLS, CaveDecorators.JUNGLE);
-        BIOME2CD.put(Biomes.MODIFIED_JUNGLE_EDGE, CaveDecorators.JUNGLE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.JUNGLE), CaveDecorators.JUNGLE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.JUNGLE_EDGE), CaveDecorators.JUNGLE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.JUNGLE_HILLS), CaveDecorators.JUNGLE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BAMBOO_JUNGLE), CaveDecorators.JUNGLE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_JUNGLE), CaveDecorators.JUNGLE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BAMBOO_JUNGLE_HILLS), CaveDecorators.JUNGLE);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_JUNGLE_EDGE), CaveDecorators.JUNGLE);
 
         //sand biomes
-        BIOME2CD.put(Biomes.DESERT, CaveDecorators.SAND);
-        BIOME2CD.put(Biomes.DESERT_HILLS, CaveDecorators.SAND);
-        BIOME2CD.put(Biomes.DESERT_LAKES, CaveDecorators.SAND);
-        BIOME2CD.put(Biomes.BEACH, CaveDecorators.SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DESERT), CaveDecorators.SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DESERT_HILLS), CaveDecorators.SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.DESERT_LAKES), CaveDecorators.SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BEACH), CaveDecorators.SAND);
 
         //red sand biomes
-        BIOME2CD.put(Biomes.BADLANDS, CaveDecorators.RED_SAND);
-        BIOME2CD.put(Biomes.BADLANDS_PLATEAU, CaveDecorators.RED_SAND);
-        BIOME2CD.put(Biomes.ERODED_BADLANDS, CaveDecorators.RED_SAND);
-        BIOME2CD.put(Biomes.MODIFIED_BADLANDS_PLATEAU, CaveDecorators.RED_SAND);
-        BIOME2CD.put(Biomes.MODIFIED_WOODED_BADLANDS_PLATEAU, CaveDecorators.RED_SAND);
-        BIOME2CD.put(Biomes.WOODED_BADLANDS_PLATEAU, CaveDecorators.RED_SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BADLANDS), CaveDecorators.RED_SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.BADLANDS_PLATEAU), CaveDecorators.RED_SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.ERODED_BADLANDS), CaveDecorators.RED_SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_BADLANDS_PLATEAU), CaveDecorators.RED_SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MODIFIED_WOODED_BADLANDS_PLATEAU), CaveDecorators.RED_SAND);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.WOODED_BADLANDS_PLATEAU), CaveDecorators.RED_SAND);
 
         //mushroom biomes
-        BIOME2CD.put(Biomes.MUSHROOM_FIELDS, CaveDecorators.MUSHROOM);
-        BIOME2CD.put(Biomes.MUSHROOM_FIELD_SHORE, CaveDecorators.MUSHROOM);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MUSHROOM_FIELDS), CaveDecorators.MUSHROOM);
+        BIOME2CD.put(BuiltinRegistries.BIOME.get(BiomeKeys.MUSHROOM_FIELD_SHORE), CaveDecorators.MUSHROOM);
     }
 
     public static void attemptAddRemainingBiomes() {
@@ -92,7 +93,7 @@ public class BiomeHandler {
 
         fullyInitialized = true;
 
-        for (Biome biome : Registry.BIOME) {
+        for (Biome biome : BuiltinRegistries.BIOME) {
             BIOME2CD.computeIfAbsent(biome, b -> {
                //attempt to add biome heuristically
 
@@ -129,7 +130,7 @@ public class BiomeHandler {
                 //So at this point we've gone through every catagory and tried our best to guess which cave would fit it.
                 //Now if we still don't know at this point, we look at the surface config and try to guess that way.
 
-                SurfaceConfig sc = b.getSurfaceConfig();
+                SurfaceConfig sc = b.getGenerationSettings().getSurfaceConfig();
 
                 //grassy surface - grassy cave
                 if (sc.getTopMaterial() == Blocks.GRASS_BLOCK.getDefaultState()) {

--- a/src/main/java/supercoder79/cavebiomes/CaveBiomes.java
+++ b/src/main/java/supercoder79/cavebiomes/CaveBiomes.java
@@ -17,7 +17,7 @@ public class CaveBiomes implements ModInitializer {
 
 	public static ConfigData CONFIG;
 
-	public static final Map<Biome, CaveDecorator> BIOME2CD = new HashMap<>();
+	public static final Map<Biome.Category, CaveDecorator> BIOME_CATEGORY_2CD = new HashMap<>();
 
 	@Override
 	public void onInitialize() {

--- a/src/main/java/supercoder79/cavebiomes/CaveBiomes.java
+++ b/src/main/java/supercoder79/cavebiomes/CaveBiomes.java
@@ -4,7 +4,6 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.biome.Biome;
-import net.minecraft.world.biome.Biomes;
 import supercoder79.cavebiomes.cave.CaveDecorator;
 import supercoder79.cavebiomes.cave.CaveDecorators;
 import supercoder79.cavebiomes.config.ConfigData;

--- a/src/main/java/supercoder79/cavebiomes/config/ConfigData.java
+++ b/src/main/java/supercoder79/cavebiomes/config/ConfigData.java
@@ -7,7 +7,6 @@ import java.util.List;
 
 public class ConfigData {
     public String configVersion = CaveBiomes.VERSION;
-    public boolean guessCaveBiomeIfAbsent = true;
     public boolean generateOreCaves = true;
     public List<String> whitelistedDimensions = Arrays.asList("minecraft:overworld");
 }

--- a/src/main/java/supercoder79/cavebiomes/magic/PublicCarverAccess.java
+++ b/src/main/java/supercoder79/cavebiomes/magic/PublicCarverAccess.java
@@ -1,0 +1,7 @@
+package supercoder79.cavebiomes.magic;
+
+import net.minecraft.world.gen.carver.Carver;
+
+public interface PublicCarverAccess {
+    Carver<?> getCarver();
+}

--- a/src/main/java/supercoder79/cavebiomes/mixin/MixinChunkGenerator.java
+++ b/src/main/java/supercoder79/cavebiomes/mixin/MixinChunkGenerator.java
@@ -40,9 +40,6 @@ public abstract class MixinChunkGenerator implements SaneCarverAccess {
     //TODO: fix this to not essentially be an overwrite
     @Override
     public void carve(long seed, ChunkRegion world, BiomeAccess biomeAccess, Chunk chunk, GenerationStep.Carver carver) {
-        // try to register stuff for biomes registered after us
-        BiomeHandler.attemptAddRemainingBiomes();
-
         //only generate in the overworld by default
         boolean shouldGenerate = true;
 
@@ -69,7 +66,7 @@ public abstract class MixinChunkGenerator implements SaneCarverAccess {
 
                 while(listIterator.hasNext()) {
                     int n = listIterator.nextIndex();
-                    Supplier<ConfiguredCarver<?>> carverSupplier = (Supplier<ConfiguredCarver<?>>) listIterator.next();
+                    @SuppressWarnings("unchecked") Supplier<ConfiguredCarver<?>> carverSupplier = (Supplier<ConfiguredCarver<?>>) listIterator.next();
                     ConfiguredCarver<?> configuredCarver = carverSupplier.get();
                     chunkRandom.setCarverSeed(seed + (long)n, l, m);
 
@@ -92,7 +89,7 @@ public abstract class MixinChunkGenerator implements SaneCarverAccess {
         if (shouldGenerate) {
             //regular biome based decoration
             Set<BlockPos> upperPos = positions.stream().filter(pos -> pos.getY() > 28).collect(Collectors.toSet());
-            CaveDecorator decorator = CaveBiomes.BIOME2CD.getOrDefault(biome, CaveDecorators.NONE);
+            CaveDecorator decorator = CaveBiomes.BIOME_CATEGORY_2CD.getOrDefault(biome.getCategory(), CaveDecorators.NONE);
             decorator.decorate(world, chunk, upperPos);
 
             //epic underground biome based decoration

--- a/src/main/java/supercoder79/cavebiomes/mixin/MixinConfiguredCarver.java
+++ b/src/main/java/supercoder79/cavebiomes/mixin/MixinConfiguredCarver.java
@@ -1,0 +1,20 @@
+package supercoder79.cavebiomes.mixin;
+
+import net.minecraft.world.gen.carver.Carver;
+import net.minecraft.world.gen.carver.CarverConfig;
+import net.minecraft.world.gen.carver.ConfiguredCarver;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import supercoder79.cavebiomes.magic.PublicCarverAccess;
+
+@Mixin(ConfiguredCarver.class)
+public class MixinConfiguredCarver<WC extends CarverConfig> implements PublicCarverAccess {
+
+    @Shadow @Final private Carver<WC> carver;
+
+    @Override
+    public Carver<?> getCarver() {
+        return this.carver;
+    }
+}

--- a/src/main/resources/cavebiomes.mixins.json
+++ b/src/main/resources/cavebiomes.mixins.json
@@ -5,7 +5,8 @@
   "mixins": [
     "MixinCarver",
     "MixinChunkGenerator",
-    "MixinChunkStatus"
+    "MixinChunkStatus",
+    "MixinConfiguredCarver"
   ],
   "client": [
   ],


### PR DESCRIPTION
Hello,

I am working on a modpack for 1.16.2 and came across this mod. I loved the mod but it hadn't been updated to 1.16.2 yet. And after downloading the source code, I understand why. It was not easy updating the code to support 1.16.2. After some trial and error, I did get it working. Here is a summary:

Because of the way biomes are created and stored in the registry in 1.16.2, there is no real good way to get a cave decorator based on the Biome class itself. So in my updates, the entire BIOME2CD Hash Map gets replaced with a BIOME_CATEGORY_2CD Hash Map which takes the category of a given biome and then sets the cave decorator based on that. Because of this, the attemptAddRemainingBiomes function was no longer necessary so I removed it. I also removed the guessCaveBiomeIfAbsent config boolean because it is essential to do so now.

In 1.16.2 the ConfiguredCarver class privatized the carver variable. Due to this, a new mixin was added that places a getCarver function allowing access to the carver variable.

There are some other updates to the code that needed to be made such as the fact that world.getWorld().getDimensionRegistryKey() no longer works.

Feel free to take a look and tell me what you think.